### PR TITLE
feat: support h/m/s format in parseTime (e.g. 1h2m3s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Useful if you forget to set it constantly like I do!
 - !timer goal 10: changes the timer goal to 10
 - !timer cycle 5: changes the current timer cycle to 5
 - !timer skip: skips the current session (either work or break)
-- !timer 15:00: changes the time of the current Pomo to 15:00
-- !timer 600: changes the time of the pomo to 10:00 (works with seconds)
+- !timer 15:00 or 15m: changes the time of the current Pomo to 15:00
+- !timer 600 or 600s or 10m: changes the time of the pomo to 10:00 (works with seconds)
 - !timer add 50: adds 50 seconds to the current time
 - !timer sub 50: adds 50 seconds to the current time
 - !timer pause

--- a/js/chatHandler.js
+++ b/js/chatHandler.js
@@ -148,33 +148,34 @@ const chatHandler = (function () {
 
   /**
    * Parses given user input of time in digital format
-   * @param time - in the format of HH:MM:SS entered by the user
-   * @return time in seconds or null if invalid
+   * @param time - in the format of HH:MM:SS or XhYmZs entered by the user
+   * @return time in seconds
    */
   function parseTime(time) {
-    let hours = 0;
-    let minutes = 0;
-    let seconds = 0;
+    let hours = 0, minutes = 0, seconds = 0;
 
-    let split = time.split(':');
-
-    if (split.length === 3) {
-      hours = parseInt(split[0]) * 60 * 60;
-      minutes = parseInt(split[1]) * 60;
-      seconds = parseInt(split[2]);
-    } else if (split.length === 2) {
-      hours = 0;
-      minutes = parseInt(split[0]) * 60;
-      seconds = parseInt(split[1]);
-    } else {
-      hours = 0;
-      minutes = 0;
-      seconds = parseInt(split[0]);
+    const hmsMatch = time.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/i);
+    if (hmsMatch) {
+      hours = parseInt(hmsMatch[1] || 0);
+      minutes = parseInt(hmsMatch[2] || 0);
+      seconds = parseInt(hmsMatch[3] || 0);
     }
 
-    let timeInSeconds = hours + minutes + seconds;
-    if (isNaN(timeInSeconds)) return null;
-    return timeInSeconds;
+    const colonMatch = time.match(/^(\d+)(?::(\d+))?(?::(\d+))?$/);
+    if (colonMatch) {
+      if (colonMatch[3] !== undefined) {
+        hours = parseInt(colonMatch[1] || 0);
+        minutes = parseInt(colonMatch[2] || 0);
+        seconds = parseInt(colonMatch[3] || 0);
+      } else if (colonMatch[2] !== undefined) {
+        minutes = parseInt(colonMatch[1] || 0);
+        seconds = parseInt(colonMatch[2] || 0);
+      } else {
+        seconds = parseInt(colonMatch[1] || 0);
+      }
+    }
+
+    return hours * 3600 + minutes * 60 + seconds;
   }
 
   function timerNotRunning(success) {

--- a/js/chatHandler.js
+++ b/js/chatHandler.js
@@ -154,25 +154,17 @@ const chatHandler = (function () {
   function parseTime(time) {
     let hours = 0, minutes = 0, seconds = 0;
 
-    const hmsMatch = time.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/i);
-    if (hmsMatch) {
-      hours = parseInt(hmsMatch[1] || 0);
-      minutes = parseInt(hmsMatch[2] || 0);
-      seconds = parseInt(hmsMatch[3] || 0);
-    }
-
     const colonMatch = time.match(/^(\d+)(?::(\d+))?(?::(\d+))?$/);
     if (colonMatch) {
-      if (colonMatch[3] !== undefined) {
-        hours = parseInt(colonMatch[1] || 0);
-        minutes = parseInt(colonMatch[2] || 0);
-        seconds = parseInt(colonMatch[3] || 0);
-      } else if (colonMatch[2] !== undefined) {
-        minutes = parseInt(colonMatch[1] || 0);
-        seconds = parseInt(colonMatch[2] || 0);
-      } else {
-        seconds = parseInt(colonMatch[1] || 0);
-      }
+      const [, hh, mm, ss] = colonMatch;
+      [hours, minutes, seconds] = ss ? [+hh, +mm, +ss] : mm ? [0, +hh, +mm] : [0, 0, +hh];
+    }
+
+    const hmsMatch = time.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+    if (hmsMatch) {
+      hours = +(hmsMatch[1] ?? 0);
+      minutes = +(hmsMatch[2] ?? 0);
+      seconds = +(hmsMatch[3] ?? 0);
     }
 
     return hours * 3600 + minutes * 60 + seconds;

--- a/js/chatHandler.js
+++ b/js/chatHandler.js
@@ -167,7 +167,8 @@ const chatHandler = (function () {
       seconds = +(hmsMatch[3] ?? 0);
     }
 
-    return hours * 3600 + minutes * 60 + seconds;
+    let timeInSeconds = hours * 3600 + minutes * 60 + seconds;
+    return timeInSeconds;
   }
 
   function timerNotRunning(success) {


### PR DESCRIPTION
This change adds support for parsing time strings using `h`, `m` and `s` suffixes in addition to the existing `HH:MM:SS` format.

Now supported formats

- Traditional: `1:02:03`, `1:02`, `183`
- New: `1h2m3s`, `1h2m`, `2m3s`, `3s`, `1h3s`

Examples
```
!timer 1h
!timer add 30m
!timer sub 2s
```