### PR TITLE
feat: add eta command to show timer end time in local time zone

### DIFF
--- a/configs.js
+++ b/configs.js
@@ -70,8 +70,8 @@ let configs = (function () {
   const cycleWrong = 'Cycle cannot be more than goal!';
   const goalWrong = 'Goal cannot be less than cycle!';
   const finishResponse = 'Good work today everyone 💪🏽';
-  const alreadyStarting =
-    'The stream is already starting or the timer is running!';
+  const alreadyStarting = 'The stream is already starting or the timer is running!';
+  const eta = '⏰ Timer will end at {time}';
 
   // Discord notifications
   const sendDiscord = false; // true or false
@@ -108,6 +108,7 @@ let configs = (function () {
     goalWrong,
     finishResponse,
     alreadyStarting,
+    eta,
   };
 
   const settings = {

--- a/js/chatHandler.js
+++ b/js/chatHandler.js
@@ -91,6 +91,9 @@ const chatHandler = (function () {
         else if (logic.isValidGoal(secondParam)) timerNotRunning(false);
         else chatItalicMessage(responses.goalWrong);
         break;
+      case 'eta':
+        logic.estimateTime();
+        break;
       case 'finish':
       case 'reset':
       case 'clear':

--- a/js/logic.js
+++ b/js/logic.js
@@ -365,7 +365,7 @@ const logic = (function () {
   }
 
   /**
-   * Adds currTime to estimateTime
+   * Adds timer eta
    * @return {string}
    */
   function estimateTime() {
@@ -377,7 +377,6 @@ const logic = (function () {
     let totalRemainingTime = currTime;
     let nextCycleNumber = cdCounter + 1;
     const lastCycle = cdCounterGoal;
-    const longBreakMod = settings.longBreakEvery * 2;
 
     while (nextCycleNumber <= lastCycle) {
       const isWork = nextCycleNumber % 2 === 1;
@@ -390,7 +389,7 @@ const logic = (function () {
           break;
         }
 
-        const isLongBreak = nextCycleNumber % longBreakMod === 0;
+        const isLongBreak = nextCycleNumber % (settings.longBreakEvery * 2) === 0;
         totalRemainingTime += isLongBreak ? settings.longBreakTime : settings.breakTime;
       }
 

--- a/js/logic.js
+++ b/js/logic.js
@@ -12,7 +12,6 @@ const logic = (function () {
   let currTime;
   let cdCounter;
   let cdCounterGoal;
-  let endTime;
 
   /**
    * Inits the pomo timer for work time
@@ -375,7 +374,30 @@ const logic = (function () {
       return false;
     }
 
-    const endTime = Date.now() + currTime * 1000;
+    let totalRemainingTime = currTime;
+    let nextCycleNumber = cdCounter + 1;
+    const lastCycle = cdCounterGoal;
+    const longBreakMod = settings.longBreakEvery * 2;
+
+    while (nextCycleNumber <= lastCycle) {
+      const isWork = nextCycleNumber % 2 === 1;
+
+      if (isWork) {
+        totalRemainingTime += settings.workTime;
+      } else {
+        // Skip adding break time if noLastBreak and this is the last cycle
+        if (settings.noLastBreak && nextCycleNumber === lastCycle) {
+          break;
+        }
+
+        const isLongBreak = nextCycleNumber % longBreakMod === 0;
+        totalRemainingTime += isLongBreak ? settings.longBreakTime : settings.breakTime;
+      }
+
+      nextCycleNumber++;
+    }
+
+    const endTime = Date.now() + totalRemainingTime * 1000;
     const timeStr = new Date(endTime).toLocaleTimeString([], {
       hour: '2-digit',
       minute: '2-digit',

--- a/js/logic.js
+++ b/js/logic.js
@@ -12,6 +12,7 @@ const logic = (function () {
   let currTime;
   let cdCounter;
   let cdCounterGoal;
+  let endTime;
 
   /**
    * Inits the pomo timer for work time
@@ -364,6 +365,27 @@ const logic = (function () {
     return minutes + ':' + seconds;
   }
 
+  /**
+   * Adds currTime to estimateTime
+   * @return {string}
+   */
+  function estimateTime() {
+    if (!isRunning) {
+      chatHandler.chatItalicMessage(responses.notRunning)
+      return false;
+    }
+
+    const endTime = Date.now() + currTime * 1000;
+    const timeStr = new Date(endTime).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    if (responses.eta) chatHandler.chatItalicMessage(responses.eta.replace('{time}', timeStr));
+
+    return timeStr;
+  }
+
   module.starting = starting;
   module.startTimer = startTimer;
   module.updateCycle = updateCycle;
@@ -375,6 +397,7 @@ const logic = (function () {
   module.skipCycle = skipCycle;
   module.pauseTimer = pauseTimer;
   module.finishTimer = finishTimer;
+  module.estimateTime = estimateTime;
 
   return module;
 })();


### PR DESCRIPTION
This change shows the exact local time when all timers are expected to finish, including breaks
```
!timer eta
```
Completes https://github.com/mohamed-tayeh/Minimal-Pomo-Timer/issues/33